### PR TITLE
Update fits schema to stand on its own

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,5 @@
 0.0.1 (unreleased)
 ------------------
 
-- Initial release [#1].
+- Initial release. [#1]
+- Update ``fits-1.0.0`` schema. [#4]

--- a/resources/stsci.edu/schemas/fits-1.0.0.yaml
+++ b/resources/stsci.edu/schemas/fits-1.0.0.yaml
@@ -21,7 +21,7 @@ examples:
   -
     - A simple FITS file with a primary header and two extensions
     - |
-        !fits/fits-1.0.0
+        !<tag:stsci.edu:asdf/fits/fits-1.0.0>
             - header:
               - [SIMPLE, true, conforms to FITS standard]
               - [BITPIX, 8, array data type]
@@ -72,7 +72,6 @@ examples:
               - [EXTNAME, ERR, extension name]
               - [BUNIT, DN, Units of the error array]
 
-tag: "tag:stsci.edu:asdf/fits/fits-1.0.0"
 type: array
 items:
   description: >


### PR DESCRIPTION
Update the `fits-1.0.0` schema so that it can stand on its own once ASDF-standard removes it.