### PR TITLE
add archiving note to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,2 @@
-# asdf-fits-schemas
-![CI](https://github.com/asdf-format/asdf-fits-schemas/workflows/CI/badge.svg)
-![Downstream](https://github.com/asdf-format/asdf-fits-schemas/workflows/Downstream/badge.svg)
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
-
-This package provides ASDF schemas for validating FITS tags.  Users should not
-need to install this directly; instead, install an implementation package such
-as asdf-astropy, which includes asdf-fits-schemas as a dependency.
+This package was never released and has been archived. The schemas in this package were never removed from and will continue to be maintained in:
+[asdf-standard](https://github.com/asdf-format/asdf-standard)


### PR DESCRIPTION
After this is merged this repository can be archived.

If the modifications here are approved I will apply a similar process to:
- https://github.com/asdf-format/asdf-time-schemas
- https://github.com/asdf-format/asdf-table-schemas

As those repositories are all part of the same abandoned effort to split the standard.